### PR TITLE
Dependent destroy games bookings

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,7 +4,7 @@ class Game < ApplicationRecord
   CATEGORIES = ["Pinball", "Pool", "Arcade game"]
 
   belongs_to :user
-  has_many :bookings
+  has_many :bookings, dependent: :destroy
   validates :address, :description, :price, :category, presence: true
   validates :description, length: { minimum: 50 }
   validates :price, numericality: { greater_than: 1 }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,8 +1,8 @@
 class Game < ApplicationRecord
   has_many_attached :photos
 
-  CATEGORIES = ["pinball", "pool", "arcade game"]
-  
+  CATEGORIES = ["Pinball", "Pool", "Arcade game"]
+
   belongs_to :user
   has_many :bookings
   validates :address, :description, :price, :category, presence: true


### PR DESCRIPTION
I add dependent: :destroy to :bookings in class Game.

I think it's good, because I delete game :id 1 (michel's game)
ActiveStorage::Blob Destroy (0.6ms)  DELETE FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1  [["id", 2]]